### PR TITLE
Updated for Patch 8.2.5 & 1.13.

### DIFF
--- a/FriendsWithBenefits.lua
+++ b/FriendsWithBenefits.lua
@@ -36,20 +36,21 @@ end
 
 local origRemoveFriend = C_FriendList.RemoveFriend
 C_FriendList.RemoveFriend = function(i, ...)
-	local name = type(i) == "number" and C_FriendList.GetFriendInfoByIndex(i) or i
+	local name = type(i) == "number" and C_FriendList.GetFriendInfoByIndex(i).name or i
 	ns.Debug("Function RemoveFriend", name, i, ...)
 	currop, currfriend = "REM", string.lower(name)
-	return origRemoveFriend(i, ...)
+	return origRemoveFriend(name, ...)
 end
-
+C_FriendList.RemoveFriendByIndex = C_FriendList.RemoveFriend
 
 local origSetFriendNotes = C_FriendList.SetFriendNotes
 C_FriendList.SetFriendNotes = function(i, note, ...)
 	ns.Debug("Function SetFriendNotes", i, note, ...)
-	local name = type(i) == "number" and C_FriendList.GetFriendInfoByIndex(i) or i
+	local name = type(i) == "number" and C_FriendList.GetFriendInfoByIndex(i).name or i
 	db.notes[string.lower(name)] = note
-	return origSetFriendNotes(i, note, ...)
+	return origSetFriendNotes(name, note, ...)
 end
+C_FriendList.SetFriendNotesByIndex = C_FriendList.SetFriendNotes
 
 
 local function FinalizeAdd()

--- a/FriendsWithBenefits.toc
+++ b/FriendsWithBenefits.toc
@@ -1,4 +1,4 @@
-## Interface: 80200
+## Interface: 80205
 
 ## Title: Friends With Benefits
 ## Notes: Syncs your friend list

--- a/FriendsWithBenefits.toc
+++ b/FriendsWithBenefits.toc
@@ -1,4 +1,4 @@
-## Interface: 80100
+## Interface: 80200
 
 ## Title: Friends With Benefits
 ## Notes: Syncs your friend list

--- a/FriendsWithBenefits.toc
+++ b/FriendsWithBenefits.toc
@@ -1,4 +1,4 @@
-## Interface: 30200
+## Interface: 80100
 
 ## Title: Friends With Benefits
 ## Notes: Syncs your friend list


### PR DESCRIPTION
The previous friend list API was [deprecated](https://www.townlong-yak.com/framexml/28768/Blizzard_Deprecated/Deprecated_8_1_0.lua#61) in [Patch 8.1: Tides of Vengeance](https://wow.gamepedia.com/Patch_8.1.0).

BTW, this is also fully compatible with the Classic client (Patch 1.13, ToC: 11302).